### PR TITLE
Fix invalid character in env var

### DIFF
--- a/doc/backlight/README.md
+++ b/doc/backlight/README.md
@@ -9,9 +9,9 @@ Print backlight brightness
 ### Required
 These options must be set to the specified values for the blocklet to work.
 
-`$i3blocks-blocklets_dir` should be set the directory containing the compiled blocklets.
+`$i3blocks_blocklets_dir` should be set the directory containing the compiled blocklets.
 ```
-command=$i3blocks-blocklets_dir/backlight
+command=$i3blocks_blocklets_dir/backlight
 ```
 ```
 interval=persist

--- a/doc/backlight/i3blocks.conf
+++ b/doc/backlight/i3blocks.conf
@@ -1,4 +1,4 @@
-command=$i3blocks-blocklets_dir/backlight
+command=$i3blocks_blocklets_dir/backlight
 interval=persist
 markup=pango
 output_format=B: %brightness

--- a/doc/battery/README.md
+++ b/doc/battery/README.md
@@ -9,9 +9,9 @@ None
 ### Required
 These options must be set to the specified values for the blocklet to work.
 
-`$i3blocks-blocklets_dir` should be set the directory containing the compiled blocklets.
+`$i3blocks_blocklets_dir` should be set the directory containing the compiled blocklets.
 ```
-command=$i3blocks-blocklets_dir/battery
+command=$i3blocks_blocklets_dir/battery
 ```
 ```
 interval=persist

--- a/doc/battery/i3blocks.conf
+++ b/doc/battery/i3blocks.conf
@@ -1,5 +1,5 @@
 [battery]
-command=$i3blocks-blocklets_dir/battery
+command=$i3blocks_blocklets_dir/battery
 interval=persist
 markup=pango
 bat_name=BAT0

--- a/doc/datetime/README.md
+++ b/doc/datetime/README.md
@@ -9,9 +9,9 @@ Print date and time
 ### Required
 These options must be set to the specified values for the blocklet to work.
 
-`$i3blocks-blocklets_dir` should be set the directory containing the compiled blocklets.
+`$i3blocks_blocklets_dir` should be set the directory containing the compiled blocklets.
 ```
-command=$i3blocks-blocklets_dir/datetime
+command=$i3blocks_blocklets_dir/datetime
 ```
 ```
 interval=1

--- a/doc/datetime/i3blocks.conf
+++ b/doc/datetime/i3blocks.conf
@@ -1,5 +1,5 @@
 [datetime]
-command=$i3blocks-blocklets_dir/datetime
+command=$i3blocks_blocklets_dir/datetime
 interval=1
 markup=pango
 output_format=%a %d-%m-%Y %H:%M:%S

--- a/doc/ethernet/README.md
+++ b/doc/ethernet/README.md
@@ -9,9 +9,9 @@ None
 ### Required
 These options must be set to the specified values for the blocklet to work.
 
-`$i3blocks-blocklets_dir` should be set the directory containing the compiled blocklets.
+`$i3blocks_blocklets_dir` should be set the directory containing the compiled blocklets.
 ```
-command=$i3blocks-blocklets_dir/battery
+command=$i3blocks_blocklets_dir/battery
 ```
 ```
 interval=persist

--- a/doc/ethernet/i3blocks.conf
+++ b/doc/ethernet/i3blocks.conf
@@ -1,5 +1,5 @@
 [ethernet]
-command=$i3blocks-blocklets_dir/ethernet
+command=$i3blocks_blocklets_dir/ethernet
 interval=persist
 markup=pango
 interface=_default_

--- a/doc/volume/README.md
+++ b/doc/volume/README.md
@@ -9,9 +9,9 @@ Print volume using PulseAudio
 ### Required
 These options must be set to the specified values for the blocklets to work.
 
-`$i3blocks-blocklets_dir` should be set the directory containing the compiled blocklets.
+`$i3blocks_blocklets_dir` should be set the directory containing the compiled blocklets.
 ```
-command=$i3blocks-blocklets_dir/battery
+command=$i3blocks_blocklets_dir/battery
 ```
 ```
 interval=persist

--- a/doc/volume/i3blocks.conf
+++ b/doc/volume/i3blocks.conf
@@ -1,5 +1,5 @@
 [volume]
-command=$i3blocks-blocklets_dir/volume
+command=$i3blocks_blocklets_dir/volume
 interval=persist
 markup=pango
 sink_idx=_default_

--- a/doc/wireless/README.md
+++ b/doc/wireless/README.md
@@ -9,9 +9,9 @@ None
 ### Required
 These options must be set to the specified values for the blocklet to work.
 
-`$i3blocks-blocklets_dir` should be set the directory containing the compiled blocklets.
+`$i3blocks_blocklets_dir` should be set the directory containing the compiled blocklets.
 ```
-command=$i3blocks-blocklets_dir/battery
+command=$i3blocks_blocklets_dir/battery
 ```
 ```
 interval=persist

--- a/doc/wireless/i3blocks.conf
+++ b/doc/wireless/i3blocks.conf
@@ -1,5 +1,5 @@
 [wireless]
-command=$i3blocks-blocklets_dir/wireless
+command=$i3blocks_blocklets_dir/wireless
 interval=persist
 markup=pango
 wireless_interface=_default_


### PR DESCRIPTION
The environment variable to point at the dir containing the blocklets that the docs suggested to create contained a '-', which is an invalid character for environment variables. Replaced with '_'