### PR TITLE
Print errors using pango

### DIFF
--- a/src/blocklets/backlight/main.cpp
+++ b/src/blocklets/backlight/main.cpp
@@ -79,17 +79,23 @@ int main()
     }
     catch (const std::runtime_error& error)
     {
-        std::cerr << "Error (std::runtime_error): " << error.what() << '\n';
+        std::string error_string{ "Error: " + std::string{ error.what() } };
+        std::cerr << error_string << '\n';
+        common::PrintPangoMarkup(error_string, "#FF0000");
         return 1;
     }
     catch (const std::exception& error)
     {
-        std::cerr << "Error (std::exception): " << error.what() << '\n';
+        std::string error_string{ "Error: " + std::string{ error.what() } };
+        std::cerr << error_string << '\n';
+        common::PrintPangoMarkup(error_string, "#FF0000");
         return 1;
     }
     catch (...)
     {
-        std::cerr << "Unknown error" << '\n';
+        std::string error_string{ "Unknown Error" };
+        std::cerr << error_string << '\n';
+        common::PrintPangoMarkup(error_string, "#FF0000");
         return 1;
     }
 }

--- a/src/blocklets/battery/main.cpp
+++ b/src/blocklets/battery/main.cpp
@@ -176,17 +176,23 @@ int main()
     }
     catch (const std::runtime_error& error)
     {
-        std::cerr << "Error (std::runtime_error): " << error.what() << '\n';
+        std::string error_string{ "Error: " + std::string{ error.what() } };
+        std::cerr << error_string << '\n';
+        common::PrintPangoMarkup(error_string, "#FF0000");
         return 1;
     }
     catch (const std::exception& error)
     {
-        std::cerr << "Error (std::exception): " << error.what() << '\n';
+        std::string error_string{ "Error: " + std::string{ error.what() } };
+        std::cerr << error_string << '\n';
+        common::PrintPangoMarkup(error_string, "#FF0000");
         return 1;
     }
     catch (...)
     {
-        std::cerr << "Unknown error" << '\n';
+        std::string error_string{ "Unknown Error" };
+        std::cerr << error_string << '\n';
+        common::PrintPangoMarkup(error_string, "#FF0000");
         return 1;
     }
 }

--- a/src/blocklets/ethernet/main.cpp
+++ b/src/blocklets/ethernet/main.cpp
@@ -76,17 +76,23 @@ int main()
     }
     catch (const std::runtime_error& error)
     {
-        std::cerr << "Error (std::runtime_error): " << error.what() << '\n';
+        std::string error_string{ "Error: " + std::string{ error.what() } };
+        std::cerr << error_string << '\n';
+        common::PrintPangoMarkup(error_string, "#FF0000");
         return 1;
     }
     catch (const std::exception& error)
     {
-        std::cerr << "Error (std::exception): " << error.what() << '\n';
+        std::string error_string{ "Error: " + std::string{ error.what() } };
+        std::cerr << error_string << '\n';
+        common::PrintPangoMarkup(error_string, "#FF0000");
         return 1;
     }
     catch(...)
     {
-        std::cerr << "Unknown error" << '\n';
+        std::string error_string{ "Unknown Error" };
+        std::cerr << error_string << '\n';
+        common::PrintPangoMarkup(error_string, "#FF0000");
         return 1;
     }
 }

--- a/src/blocklets/volume/main.cpp
+++ b/src/blocklets/volume/main.cpp
@@ -98,17 +98,23 @@ int main()
     }
     catch (const std::runtime_error& error)
     {
-        std::cerr << "Error (std::runtime_error): " << error.what() << '\n';
+        std::string error_string{ "Error: " + std::string{ error.what() } };
+        std::cerr << error_string << '\n';
+        common::PrintPangoMarkup(error_string, "#FF0000");
         return 1;
     }
     catch (const std::exception& error)
     {
-        std::cerr << "Error (std::exception): " << error.what() << '\n';
+        std::string error_string{ "Error: " + std::string{ error.what() } };
+        std::cerr << error_string << '\n';
+        common::PrintPangoMarkup(error_string, "#FF0000");
         return 1;
     }
     catch (...)
     {
-        std::cerr << "Unknown error" << '\n';
+        std::string error_string{ "Unknown Error" };
+        std::cerr << error_string << '\n';
+        common::PrintPangoMarkup(error_string, "#FF0000");
         return 1;
     }
 }

--- a/src/blocklets/wireless/main.cpp
+++ b/src/blocklets/wireless/main.cpp
@@ -96,17 +96,23 @@ int main()
     }
     catch (const std::runtime_error& error)
     {
-        std::cerr << "Error (std::runtime_error): " << error.what() << '\n';
+        std::string error_string{ "Error: " + std::string{ error.what() } };
+        std::cerr << error_string << '\n';
+        common::PrintPangoMarkup(error_string, "#FF0000");
         return 1;
     }
     catch (const std::exception& error)
     {
-        std::cerr << "Error (std::exception): " << error.what() << '\n';
+        std::string error_string{ "Error: " + std::string{ error.what() } };
+        std::cerr << error_string << '\n';
+        common::PrintPangoMarkup(error_string, "#FF0000");
         return 1;
     }
     catch(...)
     {
-        std::cerr << "Unknown error" << '\n';
+        std::string error_string{ "Unknown Error" };
+        std::cerr << error_string << '\n';
+        common::PrintPangoMarkup(error_string, "#FF0000");
         return 1;
     }
 }


### PR DESCRIPTION
All blocklets (except for datetime which doesn't have or need proper error handling) will now print errors using pango so that errors can be recognized in the status bar itself. Note that errors are printed using `std::cerr` first so that they will still be printed if for some reason `common::PrintPangoMarkup` throws an exception.