### PR TITLE
Rewrite backlight blocklet to use sysfs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ i3blocks-blocklets can be installed from the source directly or as an AUR packag
 
 ### Source
 Install dependencies
-- [light](https://github.com/haikarainen/light) (for backlight blocklet)
 - [PulseAudio](https://www.freedesktop.org/wiki/Software/PulseAudio/) (for volume blocklet)
 
 Acquire the sources

--- a/doc/backlight/README.md
+++ b/doc/backlight/README.md
@@ -2,7 +2,7 @@
 Print backlight brightness
 
 ## Dependencies
-[light](https://github.com/haikarainen/light)
+None
 
 ## Configuration options
 
@@ -23,11 +23,15 @@ markup=pango
 ### Optional
 These options allow you to customize the blocklet.
 
+The backlight device to monitor. It should refer to a directory under `/sys/class/backlight/`. The special value `_default_` will tell the blocklet to use the first backlight device found. Not setting this option is equivalent to `_default_`.
+```
+backlight_device=_default_
+```
 The text to be printed when the blocklet is functioning.
 ```
 output_format=B: %brightness
 ```
-The text to be printed when `light` is not installed.
+The text to be printed when no backlight device is found.
 ```
 output_format_down=No backlight
 ```
@@ -35,7 +39,7 @@ The color of the text when the blocklet is functioning.
 ```
 color=#FFFFFF
 ```
-The color of the text when `light` is not installed.
+The color of the text when no backlight device is found.
 ```
 color_down=#FF0000
 ```
@@ -53,7 +57,6 @@ See [i3blocks.conf](i3blocks.conf)
 ## More information
 - Although the blocklet is update once a second, the `interval` is set to `persist` rather than `1` for performance reasons (no need to re-fetch environment variables each time).
 - The blocklet will also be updated if it receives a `SIGUSR1` signal. Note that signal should be sent to the blocklet itself, not `i3blocks`.
-- If `light` is not installed, the blocklet will switch into non-functioning mode. However if `light` is installed but no backlight controller is found `%brightness` will be set to `0%`.
 
 ## Bonus
 The following can be inserted into your `i3` config to enable changing your backlight brightness via keybinds while automatically sending `SIGUSR1` to the blocklet to update it.

--- a/doc/backlight/i3blocks.conf
+++ b/doc/backlight/i3blocks.conf
@@ -1,6 +1,7 @@
 command=$i3blocks_blocklets_dir/backlight
 interval=persist
 markup=pango
+backlight_device=_default_
 output_format=B: %brightness
 output_format_down=No backlight
 color=#FFFFFF

--- a/src/blocklets/backlight/backlight.cpp
+++ b/src/blocklets/backlight/backlight.cpp
@@ -1,30 +1,48 @@
 #include "backlight.hpp"
 
 #include "../../common/common.hpp"
-#include "../../common/missing_dependency_error/missing_dependency_error.hpp"
 
 #include <cmath>
+#include <exception>
+#include <filesystem>
+#include <stdexcept>
 #include <string>
 #include <sstream>
+
+const std::string Backlight::m_s_c_backlight_sys_path{ "/sys/class/backlight/" };
 
 Backlight::Backlight()
     : m_brightness{ -1 }
 {
-    if (common::CheckIfProgramExistsInPath("light") == false)
+    namespace sfs = std::filesystem;
+
+    if (sfs::is_empty(m_s_c_backlight_sys_path) == true)
     {
-        throw common::MissingDependencyError{ "light" };
+        throw NoBacklightDeviceError{};
     }
 
-    m_brightness = std::stod(common::ExecCmdReadFirstLine("light -G"));
+    sfs::directory_iterator di{ m_s_c_backlight_sys_path };
+    m_device_name = (di->path().filename().string());
+    m_device_path = std::string{ (di->path().string()) + "/" };
+
+    ReadAndCalcBrightness();
+}
+
+Backlight::Backlight(const std::string& device_name)
+    : m_brightness{ -1 }
+{
+    m_device_name = device_name;
+    m_device_path = std::string{ m_s_c_backlight_sys_path + device_name + "/"};
+
+    ReadAndCalcBrightness();
 }
 
 Backlight::Backlight(const Backlight& other)
-    : m_brightness{ other.m_brightness }
+    : m_device_name{ other.m_device_name },
+      m_device_path{ other.m_device_path },
+      m_brightness{ other.m_brightness }
 {
-    if (common::CheckIfProgramExistsInPath("light") == false)
-    {
-        throw common::MissingDependencyError{ "light" };
-    }
+    CheckThatDeviceExists();
 }
 
 Backlight& Backlight::operator= (const Backlight& other)
@@ -34,7 +52,11 @@ Backlight& Backlight::operator= (const Backlight& other)
         return *this;
     }
 
+    m_device_name = other.m_device_name;
+    m_device_path = other.m_device_path;
     m_brightness = other.m_brightness;
+
+    CheckThatDeviceExists();
 
     return *this;
 }
@@ -44,9 +66,11 @@ double Backlight::GetBrightness() const
     return m_brightness;
 }
 
+#include <iostream>
 std::string Backlight::GetFormattedBrightness() const
 {
-    if (m_brightness == static_cast<int>(m_brightness))
+    /*
+    if (common::ApproximatelyEqualAbsRel(m_brightness, static_cast<int>(m_brightness)))
     {
         return std::string{ std::to_string(static_cast<int>(std::round(m_brightness))) + "%" };
     }
@@ -59,14 +83,71 @@ std::string Backlight::GetFormattedBrightness() const
 
         return std::string{ sstream.str() + "%" };
     }
+    */
+
+    return std::string{ std::to_string(static_cast<int>(std::round(m_brightness))) + "%" };
 }
 
 void Backlight::SetBrightness(double brightness)
 {
-    common::ExecCmdDontRead(std::string{ "light -S " + std::to_string(brightness) });
+    //TODO
+    double max_brightness{ std::stod(common::ReadFirstLineOfFile(std::string{ m_device_path + "/max_brightness" })) };
+    double actual_brightness{ (brightness / 100) * max_brightness };
 }
 
 void Backlight::Update()
 {
-    m_brightness = std::stod(common::ExecCmdReadFirstLine("light -G"));
+    ReadAndCalcBrightness();
+}
+
+void Backlight::CheckThatDeviceExists()
+{
+   namespace sfs = std::filesystem;
+
+    if ((sfs::is_directory(m_device_path) == false) && (sfs::is_symlink(m_device_path) == false))
+    {
+        throw NoBacklightDeviceError{};
+    }
+}
+
+void Backlight::ReadAndCalcBrightness()
+{
+    CheckThatDeviceExists();
+
+    double actual_brightness{ std::stod(common::ReadFirstLineOfFile(std::string{ m_device_path + "/actual_brightness"})) };
+    double max_brightness{ std::stod(common::ReadFirstLineOfFile(std::string{ m_device_path + "/max_brightness" })) };
+
+    m_brightness = ((actual_brightness / max_brightness) * 100);
+}
+
+const std::string Backlight::NoBacklightDeviceError::m_s_c_what_arg{ "No backlight device found" };
+
+Backlight::NoBacklightDeviceError::NoBacklightDeviceError()
+    : std::runtime_error{ m_s_c_what_arg }
+{
+}
+
+Backlight::NoBacklightDeviceError::NoBacklightDeviceError(const NoBacklightDeviceError& other) noexcept
+:   std::runtime_error{ other }
+{
+}
+
+Backlight::NoBacklightDeviceError::~NoBacklightDeviceError()
+{
+}
+
+Backlight::NoBacklightDeviceError& Backlight::NoBacklightDeviceError::operator=(const NoBacklightDeviceError& other) noexcept
+{
+    if (this == &other)
+    {
+        return *this;
+    }
+
+    std::runtime_error::operator=(other);
+    return *this;
+}
+
+const char* Backlight::NoBacklightDeviceError::what() const noexcept
+{
+    return std::runtime_error::what();
 }

--- a/src/blocklets/backlight/backlight.hpp
+++ b/src/blocklets/backlight/backlight.hpp
@@ -3,17 +3,24 @@
 #ifndef BACKLIGHT_HPP
 #define BACKLIGHT_HPP
 
+#include <exception>
+#include <stdexcept>
 #include <string>
 
 class Backlight
 {
     private:
 
+        static const std::string m_s_c_backlight_sys_path;
+
+        std::string m_device_name;
+        std::string m_device_path;
         double m_brightness;
 
     public:
 
         Backlight();
+        Backlight(const std::string& device_name);
         Backlight(const Backlight& other);
 
         Backlight& operator= (const Backlight& other);
@@ -22,6 +29,35 @@ class Backlight
         std::string GetFormattedBrightness() const;
         void SetBrightness(double brightness);
         void Update();
+
+    private:
+
+        void CheckThatDeviceExists();
+        void ReadAndCalcBrightness();
+
+    public:
+
+        class NoBacklightDeviceError : public std::runtime_error
+        {
+            private:
+
+                static const std::string m_s_c_what_arg;
+
+            public:
+
+                NoBacklightDeviceError();
+                NoBacklightDeviceError(const NoBacklightDeviceError& other) noexcept;
+
+                virtual ~NoBacklightDeviceError();
+
+            public:
+
+                NoBacklightDeviceError& operator=(const NoBacklightDeviceError& other) noexcept;
+
+            public:
+
+                virtual const char* what() const noexcept override;
+        };
 };
 
 #endif

--- a/src/blocklets/backlight/main.cpp
+++ b/src/blocklets/backlight/main.cpp
@@ -1,6 +1,5 @@
 #include "backlight.hpp"
 #include "../../common/common.hpp"
-#include "../../common/missing_dependency_error/missing_dependency_error.hpp"
 
 #include <chrono>
 #include <csignal>
@@ -38,11 +37,22 @@ int main()
     {
         std::signal(SIGUSR1, sigusr1);
 
+        std::string env_backlight_device{ common::GetEnvWrapperExtraEmpties("backlight_device", "", { "_default_" }) };
+
         std::string env_output_format{ common::GetEnvWrapper("output_format", "%brightness") };
 
         const std::string env_color{ common::GetEnvWrapper("color", "#FFFFFF") };
 
-        Backlight backlight{};
+        Backlight backlight;
+
+        if (env_backlight_device != "")
+        {
+            backlight = Backlight{ env_backlight_device };
+        }
+        else
+        {
+            backlight = Backlight{};
+        }
 
         while (true)
         {
@@ -54,7 +64,7 @@ int main()
 
         return 0;
     }
-    catch (const common::MissingDependencyError& error)
+    catch (const Backlight::NoBacklightDeviceError& error)
     {
         const std::string env_output_format_down{ common::GetEnvWrapper("output_format_down", "No backlight") };
         const std::string env_color_down{ common::GetEnvWrapper("color_down", "#FFFFFF") };

--- a/src/common/common.cpp
+++ b/src/common/common.cpp
@@ -46,6 +46,33 @@ std::string common::ReadFirstLineOfFile(const std::string& file_name)
     return file_contents;
 }
 
+void WriteLinesToFile(const std::string& file_name, const std::vector<std::string>& to_write)
+{
+    std::ofstream output_file{ file_name };
+
+    if (!output_file)
+    {
+        throw std::runtime_error{ "Cannot open file for writing" };
+    }
+
+    for (size_t i{ 0 }; i < to_write.size(); ++i)
+    {
+        output_file << to_write[i] << '\n';
+    }
+}
+
+void WriteOneLineToFile(const std::string& file_name, const std::string& to_write)
+{
+    std::ofstream output_file{ file_name };
+
+    if (!output_file)
+    {
+        throw std::runtime_error{ "Cannot open file for writing" };
+    }
+
+    output_file << to_write << '\n';
+}
+
 std::vector<std::string> common::ExecCmdReadWholeOut(const std::string& cmd)
 {
     std::FILE* fp;
@@ -236,4 +263,16 @@ bool common::CheckIfProgramExistsInPath(const std::string& program)
     }
 
     return false;
+}
+
+bool common::ApproximatelyEqualAbsRel(double a, double b, double absEpsilon, double relEpsilon)
+{
+    double diff{ std::abs(a - b) };
+
+    if (diff <= absEpsilon)
+    {
+        return true;
+    }
+
+    return (diff <= (std::max(std::abs(a), std::abs(b)) * relEpsilon));
 }

--- a/src/common/common.hpp
+++ b/src/common/common.hpp
@@ -16,6 +16,8 @@ namespace common
 
     std::vector<std::string> ReadWholeFile(const std::string& file_name);
     std::string ReadFirstLineOfFile(const std::string& file_name);
+    void WriteLinesToFile(const std::string& file_name, const std::vector<std::string>& to_write);
+    void WriteOneLineToFile(const std::string& file_name, const std::string& to_write);
     std::vector<std::string> ExecCmdReadWholeOut(const std::string& cmd);
     std::string ExecCmdReadFirstLine(const std::string& cmd);
     void ExecCmdDontRead(const std::string& cmd);
@@ -25,6 +27,7 @@ namespace common
     void ReplacePangoSpecialChars(std::string& str);
     void PrintPangoMarkup( std::string full_text,  std::string color);
     bool CheckIfProgramExistsInPath(const std::string& program);
+    bool ApproximatelyEqualAbsRel(double a, double b, double absEpsilon = 1e-12, double relEpsilon = 1e-8);
 }
 
 #endif


### PR DESCRIPTION
The backlight blocklet currently calls `light`. With this rewrite the blocklet will now read the required information from `/sys`. Besides getting rid of a dependency, this should also have a slight performance boost. Users are now able to specify a specific backlight device to monitor. This change should also reduce confusion about whether `light` was not installed, the backlight was set to 0%, or no backlight device was found. Documentation has been updated accordingly.