### PR TITLE
Add fallback attributes for battery blocklet time calculation

### DIFF
--- a/src/blocklets/battery/battery.hpp
+++ b/src/blocklets/battery/battery.hpp
@@ -11,6 +11,15 @@ class Battery
 {
     private:
 
+        enum class AttrsForTimeCalc
+        {
+            charge_and_current,
+            energy_and_power,
+            max,
+        };
+
+    private:
+
         std::string m_name;
         std::string m_state;
         double m_percent;
@@ -33,6 +42,10 @@ class Battery
         std::string GetFormattedTime() const;
 
         void UpdateStatus();
+
+    private:
+
+        AttrsForTimeCalc FindAvailableAttrs(const std::string& bat_path);
 
     public:
 


### PR DESCRIPTION
Allows battery blocklet to fall back to `energy_*` and `power_now` attributes in `/sys`  for time calculation if the default `charge_*` and `current_now` aren't found.

Should allow the battery blocklet to work on a wider ranger of devices.

Fixes #35.