### PR TITLE
Resolve minor error in `build_all.sh`

### DIFF
--- a/build_all.sh
+++ b/build_all.sh
@@ -13,7 +13,7 @@ function copy_script() {
     cd ../../../
 }
 
-mkdir bin
+mkdir -p bin
 
 build backlight
 build battery


### PR DESCRIPTION
Change `mkdir bin`  command so that no error is produced if `bin` directory already exists/