### PR TITLE
Add decimal support to backlight blocklet

### DIFF
--- a/doc/backlight/README.md
+++ b/doc/backlight/README.md
@@ -43,6 +43,10 @@ The color of the text when no backlight device is found.
 ```
 color_down=#FF0000
 ```
+Whether the brightness value should be printed with decimals or not. Valid options are `never`, `always`, and `auto`. The `auto` option will cause the brightness to be printed with decimals only if it's not an integer. Note that the number of decimals places will always be either 0 or 2.
+```
+decimals=never
+```
 
 ### Variables that can be used in `output_format`
 

--- a/src/blocklets/backlight/backlight.cpp
+++ b/src/blocklets/backlight/backlight.cpp
@@ -66,8 +66,7 @@ double Backlight::GetBrightness() const
     return m_brightness;
 }
 
-#include <iostream>
-std::string Backlight::GetFormattedBrightness() const
+std::string Backlight::GetFormattedBrightness(DecimalFormat decimal_format) const
 {
     /*
     if (common::ApproximatelyEqualAbsRel(m_brightness, static_cast<int>(m_brightness)))
@@ -85,7 +84,39 @@ std::string Backlight::GetFormattedBrightness() const
     }
     */
 
-    return std::string{ std::to_string(static_cast<int>(std::round(m_brightness))) + "%" };
+    while (true)
+    {
+        switch (decimal_format)
+        {
+            case DecimalFormat::never:
+                {
+                    return std::string{ std::to_string(static_cast<int>(std::round(m_brightness))) + "%" };
+                }
+                break;
+
+            case DecimalFormat::always:
+                {
+                    std::ostringstream out;
+                    out.precision(2);
+                    out << std::fixed << m_brightness;
+                    return std::string{ out.str() + "%"};
+                }
+                break;
+
+            case DecimalFormat::automatic:
+                {
+                    if (m_brightness == std::floor(m_brightness))
+                    {
+                        decimal_format = DecimalFormat::never;
+                    }
+                    else
+                    {
+                        decimal_format = DecimalFormat::always;
+                    }
+                }
+                break;
+        }
+    }
 }
 
 void Backlight::SetBrightness(double brightness)

--- a/src/blocklets/backlight/backlight.hpp
+++ b/src/blocklets/backlight/backlight.hpp
@@ -9,6 +9,15 @@
 
 class Backlight
 {
+    public:
+
+        enum class DecimalFormat
+        {
+            always,
+            never,
+            automatic,
+        };
+
     private:
 
         static const std::string m_s_c_backlight_sys_path;
@@ -26,7 +35,7 @@ class Backlight
         Backlight& operator= (const Backlight& other);
 
         double GetBrightness() const;
-        std::string GetFormattedBrightness() const;
+        std::string GetFormattedBrightness(DecimalFormat decimal_format) const;
         void SetBrightness(double brightness);
         void Update();
 

--- a/src/blocklets/backlight/main.cpp
+++ b/src/blocklets/backlight/main.cpp
@@ -16,12 +16,13 @@ void sigusr1(int sig)
 void Print(
     const Backlight& backlight,
     const std::string& env_output_format,
-    const std::string& env_color
+    const std::string& env_color,
+    Backlight::DecimalFormat decimal_format
 )
 {
     std::string output_format{ env_output_format };
 
-    const std::string& backlight_brightness{ backlight.GetFormattedBrightness() };
+    const std::string& backlight_brightness{ backlight.GetFormattedBrightness(decimal_format) };
 
     common::ReplaceAll(output_format, "%brightness", backlight_brightness);
 
@@ -43,6 +44,25 @@ int main()
 
         const std::string env_color{ common::GetEnvWrapper("color", "#FFFFFF") };
 
+        std::string env_decimals{ common::GetEnvWrapper("decimals", "never") };
+        Backlight::DecimalFormat decimal_format{};
+        if (env_decimals == "never")
+        {
+            decimal_format = Backlight::DecimalFormat::never;
+        }
+        else if (env_decimals == "always")
+        {
+            decimal_format = Backlight::DecimalFormat::always;
+        }
+        else if (env_decimals == "auto")
+        {
+            decimal_format = Backlight::DecimalFormat::automatic;
+        }
+        else
+        {
+            throw std::runtime_error{ "invalid `decimals` setting; valid options are `always`, `never`, and `auto`" };
+        }
+
         Backlight backlight;
 
         if (env_backlight_device != "")
@@ -57,7 +77,7 @@ int main()
         while (true)
         {
             backlight.Update();
-            Print(backlight, env_output_format, env_color);
+            Print(backlight, env_output_format, env_color, decimal_format);
 
             sleep(1);
         }


### PR DESCRIPTION
Add support for printing backlight brightness with decimals. Added configuration options to print with decimals always, never, and automatically. Documentation has been updated accordingly