### PR TITLE
Update backlight i3blocks.conf with decimal options

### DIFF
--- a/doc/backlight/i3blocks.conf
+++ b/doc/backlight/i3blocks.conf
@@ -6,3 +6,4 @@ output_format=B: %brightness
 output_format_down=No backlight
 color=#FFFFFF
 color_down=#FF0000
+decimals=never


### PR DESCRIPTION
When updating the documentation after adding support for printing with decimals, I forgot to update the example `i3blocks.conf`. This resolves that.