### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,6 @@ volume | Print volume using PulseAudio
 wireless | Print wireless information
 
 ## Installation
-jasper-i3blocks-blocklets can be installed from the source directly or as an AUR package.
-
-### Source
 Install dependencies
 - [PulseAudio](https://www.freedesktop.org/wiki/Software/PulseAudio/) (for volume blocklet)
 
@@ -33,9 +30,6 @@ Build all the blocklets
 $ ./build_all.sh
 ```
 The resulting compiled blocklets can be found in the `bin/` directory
-
-### AUR
-The AUR package can be found at [jasper-i3blocks-blocklets-git](https://aur.archlinux.org/packages/jasper-i3blocks-blocklets-git). See this [ArchWiki page](https://wiki.archlinux.org/title/Arch_User_Repository) for instructions on how to install an AUR package.
 
 ## Usage
 The documentation for a particular blocklet (including an example i3blocks.conf) can be found in the `doc/` directory.


### PR DESCRIPTION
Update to `README.md` to reflect the fact that the AUR package is no longer available (it was deleted in preparation for the project rebirth as an i3status alternative).